### PR TITLE
add --version flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ IMAGE_NAME=secrets-store-csi-driver-provider-vault
 IMAGE_VERSION?=$(shell git tag | tail -1)
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 IMAGE_TAG_LATEST=$(REGISTRY_NAME)/$(IMAGE_NAME):latest
-LDFLAGS?='-X github.com/hashicorp/secrets-store-csi-driver-provider-vault/main.version=$(IMAGE_VERSION) -extldflags "-static"'
+BUILD_DATE=$$(date +%Y-%m-%d-%H:%M)
+LDFLAGS?="-X main.BuildVersion=$(IMAGE_VERSION) -X main.BuildDate=$(BUILD_DATE) -extldflags "-static""
 GOOS=linux
 GOARCH=amd64
 
@@ -28,7 +29,7 @@ sanity-test:
 	go test -v ./test/sanity
 
 build: setup
-	CGO_ENABLED=0 go build -tags 'no_mock_provider' -a -ldflags ${LDFLAGS} -o _output/secrets-store-csi-driver-provider-vault_$(GOOS)_$(GOARCH)_$(IMAGE_VERSION) main.go provider.go 
+	GOOS=linux CGO_ENABLED=0 go build -a -ldflags $(LDFLAGS) -o _output/secrets-store-csi-driver-provider-vault_$(GOOS)_$(GOARCH)_$(IMAGE_VERSION) .
 
 image: build 
 	docker build --build-arg VERSION=$(IMAGE_VERSION) --no-cache -t $(IMAGE_TAG) .

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ sanity-test:
 	go test -v ./test/sanity
 
 build: setup
-	GOOS=linux CGO_ENABLED=0 go build -a -ldflags $(LDFLAGS) -o _output/secrets-store-csi-driver-provider-vault_$(GOOS)_$(GOARCH)_$(IMAGE_VERSION) .
+	CGO_ENABLED=0 go build -a -ldflags $(LDFLAGS) -o _output/secrets-store-csi-driver-provider-vault_$(GOOS)_$(GOARCH)_$(IMAGE_VERSION) .
 
 image: build 
 	docker build --build-arg VERSION=$(IMAGE_VERSION) --no-cache -t $(IMAGE_TAG) .

--- a/main.go
+++ b/main.go
@@ -17,6 +17,9 @@ var (
 	targetPath = pflag.String("targetPath", "", "Target path to write data.")
 	permission = pflag.String("permission", "", "File permission")
 	debug      = pflag.Bool("debug", false, "sets log to debug level")
+	version    = pflag.Bool("version", false, "prints the version information")
+
+	minDriverVersion = "v0.0.8"
 )
 
 // LogHook is used to setup custom hooks
@@ -33,6 +36,13 @@ func main() {
 	var err error
 
 	setupLogger()
+
+	if *version {
+		if err = printVersion(); err != nil {
+			log.Fatalf("failed to print version, err: %+v", err)
+		}
+		os.Exit(0)
+	}
 
 	err = json.Unmarshal([]byte(*attributes), &attrib)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -18,9 +19,9 @@ var (
 	permission = pflag.String("permission", "", "File permission")
 	debug      = pflag.Bool("debug", false, "sets log to debug level")
 	version    = pflag.Bool("version", false, "prints the version information")
-
-	minDriverVersion = "v0.0.8"
 )
+
+const minDriverVersion = "v0.0.8"
 
 // LogHook is used to setup custom hooks
 type LogHook struct {
@@ -33,18 +34,20 @@ func main() {
 
 	var attrib, secret map[string]string
 	var filePermission os.FileMode
-	var err error
 
 	setupLogger()
 
 	if *version {
-		if err = printVersion(); err != nil {
+		v, err := getVersion()
+		if err != nil {
 			log.Fatalf("failed to print version, err: %+v", err)
 		}
+		// print the version and exit
+		fmt.Printf("%s\n", v)
 		os.Exit(0)
 	}
 
-	err = json.Unmarshal([]byte(*attributes), &attrib)
+	err := json.Unmarshal([]byte(*attributes), &attrib)
 	if err != nil {
 		log.Fatalf("failed to unmarshal attributes, err: %v", err)
 	}

--- a/version.go
+++ b/version.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+var (
+	// BuildDate is date when binary was built
+	BuildDate string
+	// BuildVersion is the version of binary
+	BuildVersion string
+)
+
+// providerVersion holds current provider version
+type providerVersion struct {
+	Version   string `json:"version"`
+	BuildDate string `json:"buildDate"`
+	// MinDriverVersion is minimum driver version the provider works with
+	MinDriverVersion string `json:"minDriverVersion"`
+}
+
+func printVersion() (err error) {
+	pv := providerVersion{
+		Version:          BuildVersion,
+		BuildDate:        BuildDate,
+		MinDriverVersion: minDriverVersion,
+	}
+
+	var res []byte
+	if res, err = json.Marshal(pv); err != nil {
+		return
+	}
+
+	fmt.Printf(string(res) + "\n")
+	return
+}

--- a/version.go
+++ b/version.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 )
 
 var (
@@ -20,18 +19,17 @@ type providerVersion struct {
 	MinDriverVersion string `json:"minDriverVersion"`
 }
 
-func printVersion() (err error) {
+func getVersion() (string, error) {
 	pv := providerVersion{
 		Version:          BuildVersion,
 		BuildDate:        BuildDate,
 		MinDriverVersion: minDriverVersion,
 	}
 
-	var res []byte
-	if res, err = json.Marshal(pv); err != nil {
-		return
+	res, err := json.Marshal(pv)
+	if err != nil {
+		return "", err
 	}
 
-	fmt.Printf(string(res) + "\n")
-	return
+	return string(res), nil
 }

--- a/version_test.go
+++ b/version_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPrintVersion(t *testing.T) {
+	BuildDate = "Now"
+	BuildVersion = "version"
+
+	old := os.Stdout // keep backup of the real stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := printVersion()
+
+	outC := make(chan string)
+	// copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	// back to normal state
+	w.Close()
+	os.Stdout = old // restoring the real stdout
+	out := <-outC
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	expected := fmt.Sprintf(`{"version":"version","buildDate":"Now","minDriverVersion":"%s"}`, minDriverVersion)
+	if strings.EqualFold(out, expected) {
+		t.Fatalf("string doesn't match, expected %s, got %s", expected, out)
+	}
+}

--- a/version_test.go
+++ b/version_test.go
@@ -1,42 +1,22 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 	"testing"
 )
 
-func TestPrintVersion(t *testing.T) {
+func TestGetVersion(t *testing.T) {
 	BuildDate = "Now"
 	BuildVersion = "version"
 
-	old := os.Stdout // keep backup of the real stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	err := printVersion()
-
-	outC := make(chan string)
-	// copy the output in a separate goroutine so printing can't block indefinitely
-	go func() {
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		outC <- buf.String()
-	}()
-
-	// back to normal state
-	w.Close()
-	os.Stdout = old // restoring the real stdout
-	out := <-outC
+	v, err := getVersion()
 
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 	expected := fmt.Sprintf(`{"version":"version","buildDate":"Now","minDriverVersion":"%s"}`, minDriverVersion)
-	if strings.EqualFold(out, expected) {
-		t.Fatalf("string doesn't match, expected %s, got %s", expected, out)
+	if !strings.EqualFold(v, expected) {
+		t.Fatalf("string doesn't match, expected %s, got %s", expected, v)
 	}
 }


### PR DESCRIPTION
fixes https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/issues/18

```
root@k8s-agentpool1-32372105-vmss000000:/etc/kubernetes/secrets-store-csi-providers/vault# ./provider-vault --version
{"version":"addversion02","buildDate":"2019-12-11-20:35","minDriverVersion":"v0.0.8"}
```