### PR TITLE
update driver name in examples and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ spec:
   volumes:
     - name: secrets-store-inline
       csi:
-        driver: secrets-store.csi.k8s.com
+        driver: secrets-store.csi.k8s.io
         readOnly: true
         volumeAttributes:
           secretProviderClass: "vault-foo"

--- a/examples/nginx-pod-vault-inline-volume-secretproviderclass.yaml
+++ b/examples/nginx-pod-vault-inline-volume-secretproviderclass.yaml
@@ -13,7 +13,7 @@ spec:
   volumes:
     - name: secrets-store-inline
       csi:
-        driver: secrets-store.csi.k8s.com
+        driver: secrets-store.csi.k8s.io
         readOnly: true
         volumeAttributes:
           secretProviderClass: "vault-foo"

--- a/examples/nginx-pod-vault-inline-volume.yaml
+++ b/examples/nginx-pod-vault-inline-volume.yaml
@@ -13,7 +13,7 @@ spec:
   volumes:
     - name: secrets-store-inline
       csi:
-        driver: secrets-store.csi.k8s.com
+        driver: secrets-store.csi.k8s.io
         readOnly: true
         volumeAttributes:
           providerName: "vault"

--- a/examples/pv-vault-csi.yaml
+++ b/examples/pv-vault-csi.yaml
@@ -9,7 +9,7 @@ spec:
     - ReadOnlyMany
   persistentVolumeReclaimPolicy: Retain
   csi:
-    driver: secrets-store.csi.k8s.com
+    driver: secrets-store.csi.k8s.io
     readOnly: true
     volumeHandle: kv
     volumeAttributes:


### PR DESCRIPTION
- Driver version `v0.0.8` has been released with the driver name changes. Updating all the examples and tests to reflect the new driver name. 