### PR TITLE
Add objectAlias support for filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Vault and use the Secrets Store CSI driver interface to mount them into Kubernet
 
 **This is an experimental project. This project isn't production ready.**
 
-## Attribution	
-This project is forked from and initially developed by our awesome partners at Microsoft (https://github.com/deislabs/secrets-store-csi-driver). Thank you to [Rita](https://github.com/deislabs/secrets-store-csi-driver/commits?author=ritazh) and [Mishra](https://github.com/deislabs/secrets-store-csi-driver/commits?author=anubhavmishra) for pushing this great project forward.	
+## Attribution
+This project is forked from and initially developed by our awesome partners at Microsoft (https://github.com/deislabs/secrets-store-csi-driver). Thank you to [Rita](https://github.com/deislabs/secrets-store-csi-driver/commits?author=ritazh) and [Mishra](https://github.com/deislabs/secrets-store-csi-driver/commits?author=anubhavmishra) for pushing this great project forward.
 
 ## Demo
 
@@ -17,7 +17,7 @@ This project is forked from and initially developed by our awesome partners at M
 The guide assumes the following:
 
 * A Kubernetes v1.16.0+ cluster up and running.
-* [Vault CLI](https://www.vaultproject.io/docs/install) 
+* [Vault CLI](https://www.vaultproject.io/docs/install)
 * A Vault cluster up and running. Instructions for spinning up a *development* Vault cluster in Kubernetes can be
 found [here](./docs/vault-setup.md).
 * [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl) installed.
@@ -90,6 +90,7 @@ spec:
         - |
           objectPath: "/foo"                    # secret path in the Vault Key-Value store e.g. vault kv put secret/foo bar=hello
           objectName: "bar"
+          objectAlias: "BAR"                    # the filename of the object when written to disk - defaults to objectName if not provided
           objectVersion: ""
 ```
 

--- a/examples/v1alpha1_secretproviderclass.yaml
+++ b/examples/v1alpha1_secretproviderclass.yaml
@@ -13,4 +13,5 @@ spec:
         - |
           objectPath: "/foo"
           objectName: "bar"
+          objectAlias: ""
           objectVersion: ""

--- a/provider.go
+++ b/provider.go
@@ -52,6 +52,8 @@ type KeyValueObject struct {
 	ObjectPath string `json:"objectPath" yaml:"objectPath"`
 	// the name of the Key-Value Vault objects
 	ObjectName string `json:"objectName" yaml:"objectName"`
+	// the filename the object will be written to
+	ObjectAlias string `json:"objectAlias" yaml:"objectAlias"`
 	// the version of the Key-Value Vault objects
 	ObjectVersion string `json:"objectVersion" yaml:"objectVersion"`
 }
@@ -449,10 +451,14 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 			return err
 		}
 		objectContent := []byte(content)
-		if err := ioutil.WriteFile(path.Join(targetPath, keyValueObject.ObjectName), objectContent, permission); err != nil {
-			return errors.Wrapf(err, "secrets-store csi driver failed to write %s at %s", keyValueObject.ObjectName, targetPath)
+		filename := keyValueObject.ObjectName
+		if keyValueObject.ObjectAlias != "" {
+			filename = keyValueObject.ObjectAlias
 		}
-		log.Infof("secrets-store csi driver wrote %s at %s", keyValueObject.ObjectName, targetPath)
+		if err := ioutil.WriteFile(path.Join(targetPath, filename), objectContent, permission); err != nil {
+			return errors.Wrapf(err, "secrets-store csi driver failed to write %s at %s", filename, targetPath)
+		}
+		log.Infof("secrets-store csi driver wrote %s at %s", filename, targetPath)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #44 

It is inspired by https://github.com/Azure/secrets-store-csi-driver-provider-azure/pull/39, define objectAlias for user who wants to specify a filename. In the current provider behavior, objectName is used as a filename, so if you want to use the same objectName in different kv paths, you can avoid overwriting by adding objectAlias.