### PR TITLE
Enforce descending directory write path

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -449,10 +449,24 @@ func (p *Provider) MountSecretsStoreObjectContent(ctx context.Context, attrib ma
 			return err
 		}
 		objectContent := []byte(content)
+		if err := validateFilePath(keyValueObject.ObjectName); err != nil {
+			return err
+		}
 		if err := ioutil.WriteFile(path.Join(targetPath, keyValueObject.ObjectName), objectContent, permission); err != nil {
 			return errors.Wrapf(err, "secrets-store csi driver failed to write %s at %s", keyValueObject.ObjectName, targetPath)
 		}
 		log.Infof("secrets-store csi driver wrote %s at %s", keyValueObject.ObjectName, targetPath)
+	}
+
+	return nil
+}
+
+func validateFilePath(path string) error {
+	segments := strings.Split(strings.ReplaceAll(path, `\`, "/"), "/")
+	for _, segment := range segments {
+		if segment == ".." {
+			return fmt.Errorf("ObjectName %q invalid, must not contain any .. segments", path)
+		}
 	}
 
 	return nil

--- a/provider_test.go
+++ b/provider_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateFilePath(t *testing.T) {
+	// Don't use filepath.Join to generate the test cases because it calls filepath.Clean
+	// which simplifies some of the test cases into less interesting paths.
+	for _, tc := range []string {
+		"",
+		".",
+		"/",
+		"bar",
+		"bar/foo",
+		"bar///foo",
+		"./bar",
+		"/foo/bar",
+		"foo/bar\\baz",
+	} {
+		err := validateFilePath(tc)
+		if err != nil {
+			t.Fatalf("Expected no error for %q but got %s", tc, err)
+		}
+	}
+}
+
+func TestValidatePath_Malformed(t *testing.T) {
+	for _, tc := range []string{
+		"../bar",
+		"foo/..",
+		"foo/../../bar",
+		"foo////..",
+	} {
+		err := validateFilePath(tc)
+		if err == nil {
+			t.Fatalf("Expected error for %q but got none", tc)
+		}
+
+		tc = strings.ReplaceAll(tc, "/", "\\")
+		err = validateFilePath(tc)
+		if err == nil {
+			t.Fatalf("Expected error for %q but got none", tc)
+		}
+	}
+}

--- a/provider_test.go
+++ b/provider_test.go
@@ -8,7 +8,7 @@ import (
 func TestValidateFilePath(t *testing.T) {
 	// Don't use filepath.Join to generate the test cases because it calls filepath.Clean
 	// which simplifies some of the test cases into less interesting paths.
-	for _, tc := range []string {
+	for _, tc := range []string{
 		"",
 		".",
 		"/",


### PR DESCRIPTION
I've tried to keep this fairly targeted, but also resilient to surprising paths or deployments, including Windows nodes, while also making it easy and reliable to test on any OS. Unfortunately the existing test coverage is pretty low, so it's a big task to write more of an integrated test.