### PR TITLE
Set GOOS and GOARCH for build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-style: setup
 	golangci-lint run
 
 build: setup
-	CGO_ENABLED=0 go build -a -ldflags $(LDFLAGS) -o _output/secrets-store-csi-driver-provider-vault_$(GOOS)_$(GOARCH)_$(IMAGE_VERSION) .
+	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -a -ldflags $(LDFLAGS) -o _output/secrets-store-csi-driver-provider-vault_$(GOOS)_$(GOARCH)_$(IMAGE_VERSION) .
 
 image: build 
 	docker build --build-arg VERSION=$(IMAGE_VERSION) --no-cache -t $(IMAGE_TAG) .


### PR DESCRIPTION
This ensures builds run on a Mac still produce a binary that honours the file name and also a working linux-based Docker container.