### PR TITLE
Add go build version to version info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,12 @@ IMAGE_VERSION?=$(shell git tag | tail -1)
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 IMAGE_TAG_LATEST=$(REGISTRY_NAME)/$(IMAGE_NAME):latest
 BUILD_DATE=$$(date +%Y-%m-%d-%H:%M)
-LDFLAGS?="-X github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/version.BuildVersion=$(IMAGE_VERSION) -X github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/version.BuildDate=$(BUILD_DATE) -extldflags "-static""
+LDFLAGS?="-X 'github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/version.BuildVersion=$(IMAGE_VERSION)' \
+	-X 'github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/version.BuildDate=$(BUILD_DATE)' \
+	-X 'github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/version.GoVersion=$(shell go version)' \
+	-extldflags "-static""
 GOOS?=linux
-GOARCH=amd64
+GOARCH?=amd64
 GOLANG_IMAGE?=docker.mirror.hashicorp.services/golang:1.15.7
 CI_TEST_ARGS=
 ifdef CI

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,24 +7,24 @@ import (
 const minDriverVersion = "v0.0.17"
 
 var (
-	// BuildDate is date when binary was built
-	BuildDate string
-	// BuildVersion is the version of binary
+	BuildDate    string
 	BuildVersion string
+	GoVersion    string
 )
 
 // providerVersion holds current provider version
 type providerVersion struct {
-	Version   string `json:"version"`
-	BuildDate string `json:"buildDate"`
-	// MinDriverVersion is minimum driver version the provider works with
-	MinDriverVersion string `json:"minDriverVersion"`
+	Version          string `json:"version"`          // Version of the binary.
+	BuildDate        string `json:"buildDate"`        // The date the binary was built.
+	GoVersion        string `json:"goVersion"`        // Version of Go the binary was built with.
+	MinDriverVersion string `json:"minDriverVersion"` // Minimum driver version the provider works with.
 }
 
 func GetVersion() (string, error) {
 	pv := providerVersion{
 		Version:          BuildVersion,
 		BuildDate:        BuildDate,
+		GoVersion:        GoVersion,
 		MinDriverVersion: minDriverVersion,
 	}
 

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -9,13 +9,14 @@ import (
 func TestGetVersion(t *testing.T) {
 	BuildDate = "Now"
 	BuildVersion = "version"
+	GoVersion = "go version x.y.z"
 
 	v, err := GetVersion()
 
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	expected := fmt.Sprintf(`{"version":"version","buildDate":"Now","minDriverVersion":"%s"}`, minDriverVersion)
+	expected := fmt.Sprintf(`{"version":"version","buildDate":"Now","goVersion":"go version x.y.z","minDriverVersion":"%s"}`, minDriverVersion)
 	if !strings.EqualFold(v, expected) {
 		t.Fatalf("string doesn't match, expected %s, got %s", expected, v)
 	}

--- a/main.go
+++ b/main.go
@@ -45,8 +45,8 @@ func realMain(logger hclog.Logger) error {
 			return fmt.Errorf("failed to print version, err: %w", err)
 		}
 		// print the version and exit
-		logger.Info(v)
-		return nil
+		_, err = fmt.Println(v)
+		return err
 	}
 
 	logger.Info("Creating new gRPC server")


### PR DESCRIPTION
Following up on a comment from #61.

```bash
./_output/secrets-store-csi-driver-provider-vault_darwin_amd64_0.0.7 --version
{"version":"0.0.7","buildDate":"2021-02-04-15:38","goVersion":"go version go1.15.7 darwin/amd64","minDriverVersion":"v0.0.17"}
```