### PR TITLE
Remove jfrog references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hashicorp.jfrog.io/docker/alpine:3.10
+FROM docker.mirror.hashicorp.services/alpine:3.10
 
 ARG VERSION
 ARG ARCH="amd64"

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ e2e-setup: e2e-container
 		--namespace=csi \
 		--set injector.enabled=false \
 		--set server.dev.enabled=true \
-		--set server.image.repository=hashicorp.jfrog.io/docker/vault
+		--set server.image.repository=docker.mirror.hashicorp.services/vault
 	kubectl apply --namespace=csi -f test/bats/configs/secrets-store-csi-driver-provider-vault.yaml
 	kubectl wait --namespace=csi --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/name=vault
 	kubectl wait --namespace=csi --for=condition=Ready --timeout=5m pod -l app=secrets-store-csi-driver-provider-vault

--- a/test/bats/configs/nginx-dynamic-creds.yaml
+++ b/test/bats/configs/nginx-dynamic-creds.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nginx-dynamic-creds
 spec:
   containers:
-  - image: hashicorp.jfrog.io/docker/nginx
+  - image: docker.mirror.hashicorp.services/nginx
     name: nginx
     volumeMounts:
     - name: secrets-store-inline

--- a/test/bats/configs/nginx-env-var.yaml
+++ b/test/bats/configs/nginx-env-var.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 0
       containers:
-      - image: hashicorp.jfrog.io/docker/nginx
+      - image: docker.mirror.hashicorp.services/nginx
         name: nginx
         env:
         - name: SECRET_USERNAME

--- a/test/bats/configs/nginx-inline-volume.yaml
+++ b/test/bats/configs/nginx-inline-volume.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nginx-inline
 spec:
   containers:
-  - image: hashicorp.jfrog.io/docker/nginx
+  - image: docker.mirror.hashicorp.services/nginx
     name: nginx
     volumeMounts:
     - name: secrets-store-inline

--- a/test/bats/configs/nginx-multiple-volumes.yaml
+++ b/test/bats/configs/nginx-multiple-volumes.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   containers:
-  - image: hashicorp.jfrog.io/docker/nginx
+  - image: docker.mirror.hashicorp.services/nginx
     name: nginx
     volumeMounts:
     - name: secrets-store-1

--- a/test/bats/configs/nginx-pki.yaml
+++ b/test/bats/configs/nginx-pki.yaml
@@ -4,7 +4,7 @@ metadata:
   name: nginx-pki
 spec:
   containers:
-  - image: hashicorp.jfrog.io/docker/nginx
+  - image: docker.mirror.hashicorp.services/nginx
     name: nginx
     volumeMounts:
     - name: secrets-store-inline

--- a/test/bats/configs/postgres-client.yaml
+++ b/test/bats/configs/postgres-client.yaml
@@ -4,7 +4,7 @@ metadata:
   name: postgres-client
 spec:
   containers:
-  - image: hashicorp.jfrog.io/docker/postgres:13-alpine
+  - image: docker.mirror.hashicorp.services/postgres:13-alpine
     name: postgres
     ports:
       - containerPort: 5432

--- a/test/bats/configs/postgres.yaml
+++ b/test/bats/configs/postgres.yaml
@@ -4,7 +4,7 @@ metadata:
   name: postgres
 spec:
   containers:
-  - image: hashicorp.jfrog.io/docker/postgres:13-alpine
+  - image: docker.mirror.hashicorp.services/postgres:13-alpine
     name: postgres
     ports:
       - containerPort: 5432


### PR DESCRIPTION
This removes all references to `hashicorp.jfrog.io` which has been replaced with a self-hosted registry, `docker.mirror.hashicorp.services`
