### PR TITLE
Simplify repository name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ references:
 
   paths:
     test-results: &TEST_RESULTS_DIR /tmp/test-results
-    working-directory: &WORKING_DIRECTORY /go/src/github.com/hashicorp/secrets-store-csi-driver-provider-vault
+    working-directory: &WORKING_DIRECTORY /go/src/github.com/hashicorp/vault-csi-provider
 
   environment: &ENVIRONMENT
     TEST_RESULTS_DIR: *TEST_RESULTS_DIR

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 CHANGES:
 
-* All secret engines are now supported [[GH-63](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/pull/63)]
+* All secret engines are now supported [[GH-63](https://github.com/hashicorp/vault-csi-provider/pull/63)]
   * **This makes several breaking changes to the configuration of the SecretProviderClass' `objects` entry**
   * There is no top-level `array` entry under `objects`
   * `objectVersion` is now ignored
@@ -12,27 +12,27 @@ CHANGES:
   * If `secretKey` is set, that is the key from the secret's data that will be written
   * If `secretKey` is not set, the whole JSON response from Vault will be written
   * `vaultSkipTLSVerify` is no longer required to be set to `"true"` if the `vaultAddress` scheme is not `https`
-* The provider will now authenticate to Vault as the requesting pod's service account [[GH-64](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/pull/64)]
+* The provider will now authenticate to Vault as the requesting pod's service account [[GH-64](https://github.com/hashicorp/vault-csi-provider/pull/64)]
   * **This is likely a breaking change for existing deployments being upgraded**
-  * secrets-store-csi-driver-provider-vault service account now requires cluster-wide permission to create service account tokens
+  * vault-csi-provider service account now requires cluster-wide permission to create service account tokens
   * auth/kubernetes mounts in Vault will now need to bind ACL policies to the requesting pods'
     service accounts instead of the provider's service account.
   * `spec.parameters.kubernetesServiceAccountPath` is now ignored and will log a warning if set
   * Min k8s version
   * API to require enabled
-* The provider now supports mTLS [[GH-65](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/pull/65)]
+* The provider now supports mTLS [[GH-65](https://github.com/hashicorp/vault-csi-provider/pull/65)]
   * `spec.parameters.vaultCAPem` is now ignored and will log a warning if set. **This is a breaking change**
   * `spec.parameters.vaultTLSClientCertPath` and `spec.parameters.vaultTLSClientKeyPath` are newly available options
 
 IMPROVEMENTS
 
-* The provider now uses the `hashicorp/vault/api` package to communicate with Vault [[GH-61](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/pull/61)]
-* `--version` flag will now print the version of Go used to build the provider [[GH-62](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/pull/62)]
-* CircleCI linting, tests and integration tests added [[GH-60](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/pull/60)]
+* The provider now uses the `hashicorp/vault/api` package to communicate with Vault [[GH-61](https://github.com/hashicorp/vault-csi-provider/pull/61)]
+* `--version` flag will now print the version of Go used to build the provider [[GH-62](https://github.com/hashicorp/vault-csi-provider/pull/62)]
+* CircleCI linting, tests and integration tests added [[GH-60](https://github.com/hashicorp/vault-csi-provider/pull/60)]
 
 ## 0.0.7 (January 20th, 2021)
 
 CHANGES:
 
-* Switch provider to gRPC. [[GH-54](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/pull/54)]
+* Switch provider to gRPC. [[GH-54](https://github.com/hashicorp/vault-csi-provider/pull/54)]
   * Note this requires at least v0.0.14 of the driver, and the driver should have 'vault' included in `--grpcSupportedProviders`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM docker.mirror.hashicorp.services/alpine:3.10
+FROM docker.mirror.hashicorp.services/alpine:3.13
 
 ARG VERSION
 ARG ARCH="amd64"
 ARG OS="linux"
 
-COPY ./_output/secrets-store-csi-driver-provider-vault_${OS}_${ARCH}_${VERSION} /bin/secrets-store-csi-driver-provider-vault
+COPY ./_output/vault-csi-provider_${OS}_${ARCH}_${VERSION} /bin/vault-csi-provider
 
-ENTRYPOINT ["/bin/secrets-store-csi-driver-provider-vault"]
+ENTRYPOINT ["/bin/vault-csi-provider"]

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 REGISTRY_NAME?=docker.io/hashicorp
-IMAGE_NAME=secrets-store-csi-driver-provider-vault
+IMAGE_NAME=vault-csi-provider
 IMAGE_VERSION?=$(shell git tag | tail -1)
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 IMAGE_TAG_LATEST=$(REGISTRY_NAME)/$(IMAGE_NAME):latest
 BUILD_DATE=$$(date +%Y-%m-%d-%H:%M)
-LDFLAGS?="-X 'github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/version.BuildVersion=$(IMAGE_VERSION)' \
-	-X 'github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/version.BuildDate=$(BUILD_DATE)' \
-	-X 'github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/version.GoVersion=$(shell go version)' \
+LDFLAGS?="-X 'github.com/hashicorp/vault-csi-provider/internal/version.BuildVersion=$(IMAGE_VERSION)' \
+	-X 'github.com/hashicorp/vault-csi-provider/internal/version.BuildDate=$(BUILD_DATE)' \
+	-X 'github.com/hashicorp/vault-csi-provider/internal/version.GoVersion=$(shell go version)' \
 	-extldflags "-static""
 GOOS?=linux
 GOARCH?=amd64
 GOLANG_IMAGE?=docker.mirror.hashicorp.services/golang:1.15.7
 CI_TEST_ARGS=
+CSI_DRIVER_VERSION=0.0.19
+VAULT_HELM_VERSION=0.9.1
 ifdef CI
 override CI_TEST_ARGS:=--junitfile=$(TEST_RESULTS_DIR)/go-test/results.xml --jsonfile=$(TEST_RESULTS_DIR)/go-test/results.json
 endif
@@ -37,7 +39,7 @@ test:
 build: clean
 	GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build \
 		-a -ldflags $(LDFLAGS) \
-		-o _output/secrets-store-csi-driver-provider-vault_$(GOOS)_$(GOARCH)_$(IMAGE_VERSION) \
+		-o _output/vault-csi-provider_$(GOOS)_$(GOARCH)_$(IMAGE_VERSION) \
 		.
 
 build-in-docker: clean
@@ -58,7 +60,7 @@ image: build-in-docker
 
 e2e-container:
 	REGISTRY_NAME="e2e" IMAGE_VERSION="latest" make image
-	kind load docker-image e2e/secrets-store-csi-driver-provider-vault:latest
+	kind load docker-image e2e/vault-csi-provider:latest
 
 docker-push:
 	docker push $(IMAGE_TAG)
@@ -67,24 +69,24 @@ docker-push:
 
 e2e-setup: e2e-container
 	kubectl create namespace csi
-	helm install secrets-store-csi-driver https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/v0.0.19/charts/secrets-store-csi-driver-0.0.19.tgz?raw=true \
+	helm install secrets-store-csi-driver https://github.com/kubernetes-sigs/secrets-store-csi-driver/blob/v$(CSI_DRIVER_VERSION)/charts/secrets-store-csi-driver-$(CSI_DRIVER_VERSION).tgz?raw=true \
 		--wait --timeout=5m \
 		--namespace=csi \
 		--set linux.image.pullPolicy="IfNotPresent" \
 		--set grpcSupportedProviders="azure;gcp;vault"
 	helm install vault-bootstrap test/bats/configs/vault \
 		--namespace=csi
-	helm install vault https://github.com/hashicorp/vault-helm/archive/v0.9.1.tar.gz \
+	helm install vault https://github.com/hashicorp/vault-helm/archive/v$(VAULT_HELM_VERSION).tar.gz \
 		--wait --timeout=5m \
 		--namespace=csi \
 		--values=test/bats/configs/vault/vault.values.yaml
-	kubectl apply --namespace=csi -f test/bats/configs/secrets-store-csi-driver-provider-vault.yaml
+	kubectl apply --namespace=csi -f test/bats/configs/vault-csi-provider.yaml
 	kubectl wait --namespace=csi --for=condition=Ready --timeout=5m pod -l app.kubernetes.io/name=vault
 	kubectl exec -i --namespace=csi vault-0 -- /bin/sh /vault/userconfig/vault-bootstrap/bootstrap.sh
-	kubectl wait --namespace=csi --for=condition=Ready --timeout=5m pod -l app=secrets-store-csi-driver-provider-vault
+	kubectl wait --namespace=csi --for=condition=Ready --timeout=5m pod -l app=vault-csi-provider
 
 e2e-teardown:
-	kubectl delete --namespace=csi --ignore-not-found -f test/bats/configs/secrets-store-csi-driver-provider-vault.yaml
+	kubectl delete --namespace=csi --ignore-not-found -f test/bats/configs/vault-csi-provider.yaml
 	helm uninstall --namespace=csi vault
 	helm uninstall --namespace=csi vault-bootstrap
 	helm uninstall --namespace=csi secrets-store-csi-driver

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ kubectl get daemonset -l app=secrets-store-csi-driver -o jsonpath="{.items[0].sp
 For linux nodes
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/hashicorp/secrets-store-csi-driver-provider-vault/master/deployment/provider-vault-installer.yaml
+kubectl apply -f https://raw.githubusercontent.com/hashicorp/vault-csi-provider/master/deployment/provider-vault-installer.yaml
 ```
 
 To validate the provider's installer is running as expected, run the following commands:

--- a/deployment/provider-vault-installer.yaml
+++ b/deployment/provider-vault-installer.yaml
@@ -1,26 +1,26 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: secrets-store-csi-driver-provider-vault
+  name: vault-csi-provider
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
-    app: csi-secrets-store-provider-vault
-  name: csi-secrets-store-provider-vault
+    app: vault-csi-provider
+  name: vault-csi-provider
 spec:
   updateStrategy:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: csi-secrets-store-provider-vault
+      app: vault-csi-provider
   template:
     metadata:
       labels:
-        app: csi-secrets-store-provider-vault
+        app: vault-csi-provider
     spec:
-      serviceAccountName: secrets-store-csi-driver-provider-vault
+      serviceAccountName: vault-csi-provider
       tolerations:
       containers:
         - name: provider-vault-installer

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/secrets-store-csi-driver-provider-vault
+module github.com/hashicorp/vault-csi-provider
 
 go 1.12
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/config"
+	"github.com/hashicorp/vault-csi-provider/internal/config"
 	"github.com/hashicorp/vault/api"
 )
 

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -13,7 +13,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/config"
+	"github.com/hashicorp/vault-csi-provider/internal/config"
 	"github.com/stretchr/testify/require"
 )
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	vaultclient "github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/client"
-	"github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/config"
+	vaultclient "github.com/hashicorp/vault-csi-provider/internal/client"
+	"github.com/hashicorp/vault-csi-provider/internal/config"
 	"github.com/hashicorp/vault/api"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/config"
+	"github.com/hashicorp/vault-csi-provider/internal/config"
 	"github.com/hashicorp/vault/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/go-hclog"
-	"github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/config"
-	"github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/provider"
-	"github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/version"
+	"github.com/hashicorp/vault-csi-provider/internal/config"
+	"github.com/hashicorp/vault-csi-provider/internal/provider"
+	"github.com/hashicorp/vault-csi-provider/internal/version"
 	pb "sigs.k8s.io/secrets-store-csi-driver/provider/v1alpha1"
 )
 
@@ -23,7 +23,7 @@ type Server struct {
 func (p *Server) Version(context.Context, *pb.VersionRequest) (*pb.VersionResponse, error) {
 	return &pb.VersionResponse{
 		Version:        "v1alpha1",
-		RuntimeName:    "secrets-store-csi-driver-provider-vault",
+		RuntimeName:    "vault-csi-provider",
 		RuntimeVersion: version.BuildVersion,
 	}, nil
 }

--- a/main.go
+++ b/main.go
@@ -10,8 +10,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-hclog"
-	providerserver "github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/server"
-	"github.com/hashicorp/secrets-store-csi-driver-provider-vault/internal/version"
+	providerserver "github.com/hashicorp/vault-csi-provider/internal/server"
+	"github.com/hashicorp/vault-csi-provider/internal/version"
 	"github.com/spf13/pflag"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"

--- a/sample/ingress-controller-tls/README.md
+++ b/sample/ingress-controller-tls/README.md
@@ -1,6 +1,6 @@
 # Using Secrets Store CSI and Vault Provider to Enable NGINX Ingress Controller with TLS
 
-This guide demonstrates steps required to setup Secrets Store CSI driver to enable applications to work with NGINX Ingress Controller with TLS stored in an external Secrets store. 
+This guide demonstrates steps required to setup Secrets Store CSI driver to enable applications to work with NGINX Ingress Controller with TLS stored in an external Secrets store.
 For more information on securing an Ingress with TLS, refer to: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
 
 # Generate a TLS Cert
@@ -35,7 +35,7 @@ helm install stable/nginx-ingress --generate-name \
 
 ## Setup Development Vault Cluster
 
-Follow this [guide](https://github.com/hashicorp/secrets-store-csi-driver-provider-vault/blob/master/docs/vault-setup.md#setting-up-a-development-vault-cluster) to setup development vault cluster that will be used to store the secrets.
+Follow this [guide](https://github.com/hashicorp/vault-csi-provider/blob/master/docs/vault-setup.md#setting-up-a-development-vault-cluster) to setup development vault cluster that will be used to store the secrets.
 
 
 **Write the certificate in the Vault key-value store**
@@ -89,7 +89,7 @@ spec:
   secretObjects:                                    # secretObjects defines the desired state of synced K8s secret objects
   - secretName: ingress-tls-csi
     type: kubernetes.io/tls
-    data: 
+    data:
     - objectName: tlskey
       key: tls.key
     - objectName: tlscrt
@@ -157,15 +157,15 @@ kubectl apply -f sample/ingress-controller-tls/ingress.yaml -n ingress-test
 ## Get the External IP of the Ingress Controller
 
 ```bash
-kubectl get service -l app=nginx-ingress --namespace ingress-test 
+kubectl get service -l app=nginx-ingress --namespace ingress-test
 NAME                                       TYPE           CLUSTER-IP     EXTERNAL-IP      PORT(S)                      AGE
 nginx-ingress-1588032400-controller        LoadBalancer   10.0.255.157   52.xx.xx.xx      80:31293/TCP,443:31265/TCP   19m
 nginx-ingress-1588032400-default-backend   ClusterIP      10.0.223.214   <none>           80/TCP                       19m
 ```
 
 ## Test Ingress with TLS
-Using `curl` to verify ingress configuration using TLS. 
-Replace the public IP with the external IP of the ingress controller service from the previous step.  
+Using `curl` to verify ingress configuration using TLS.
+Replace the public IP with the external IP of the ingress controller service from the previous step.
 
 ```bash
 curl -v -k --resolve demo.test.com:443:52.xx.xx.xx https://demo.test.com

--- a/test/bats/configs/vault-csi-provider.yaml
+++ b/test/bats/configs/vault-csi-provider.yaml
@@ -2,14 +2,14 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: secrets-store-csi-driver-provider-vault
+  name: vault-csi-provider
   labels:
-    app: secrets-store-csi-driver-provider-vault
+    app: vault-csi-provider
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: secrets-store-csi-driver-provider-vault-clusterrole
+  name: vault-csi-provider-clusterrole
 rules:
 - apiGroups:
   - ""
@@ -21,37 +21,37 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: secrets-store-csi-driver-provider-vault-clusterrolebinding
+  name: vault-csi-provider-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: secrets-store-csi-driver-provider-vault-clusterrole
+  name: vault-csi-provider-clusterrole
 subjects:
 - kind: ServiceAccount
-  name: secrets-store-csi-driver-provider-vault
+  name: vault-csi-provider
   namespace: csi
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: secrets-store-csi-driver-provider-vault
+  name: vault-csi-provider
   labels:
-    app: secrets-store-csi-driver-provider-vault
+    app: vault-csi-provider
 spec:
   updateStrategy:
     type: RollingUpdate
   selector:
     matchLabels:
-      app: secrets-store-csi-driver-provider-vault
+      app: vault-csi-provider
   template:
     metadata:
       labels:
-        app: secrets-store-csi-driver-provider-vault
+        app: vault-csi-provider
     spec:
-      serviceAccountName: secrets-store-csi-driver-provider-vault
+      serviceAccountName: vault-csi-provider
       containers:
-        - name: secrets-store-csi-driver-provider-vault
-          image: "e2e/secrets-store-csi-driver-provider-vault:latest"
+        - name: vault-csi-provider
+          image: "e2e/vault-csi-provider:latest"
           imagePullPolicy: Never
           args:
             - --endpoint=/provider/vault.sock

--- a/test/bats/provider.bats
+++ b/test/bats/provider.bats
@@ -92,7 +92,7 @@ teardown(){
         echo "DESCRIBE NGINX PODS"
         kubectl describe pod -l app=nginx --all-namespaces=true
         echo "PROVIDER LOGS"
-        kubectl --namespace=csi logs -l app=secrets-store-csi-driver-provider-vault --tail=50
+        kubectl --namespace=csi logs -l app=vault-csi-provider --tail=50
     fi
 
     # Teardown Vault configuration.


### PR DESCRIPTION
In anticipation of simplifying the repository names (project and docker), I've made the necessary changes to the project files. The new name of this project is `vault-csi-provider`.

The published docker repository will be left unchanged to support older releases of CSI, however, a new repository will be created and all images will be published there moving forward.

I've left the repository in the deployment file alone as this currently points to the latest experimental release. We'll want to update this when we release the new provider.