### PR TITLE
Add health handler

### DIFF
--- a/deployment/provider-vault-installer.yaml
+++ b/deployment/provider-vault-installer.yaml
@@ -42,6 +42,26 @@ spec:
             - name: mountpoint-dir
               mountPath: /var/lib/kubelet/pods
               mountPropagation: HostToContainer
+          livenessProbe:
+            httpGet:
+              path: "/health/ready"
+              port: 8080
+              scheme: "HTTP"
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
+          readinessProbe:
+            httpGet:
+              path: "/health/ready"
+              port: 8080
+              scheme: "HTTP"
+            failureThreshold: 2
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 3
       volumes:
         - name: providervol
           hostPath:

--- a/main.go
+++ b/main.go
@@ -55,18 +55,6 @@ func realMain(logger hclog.Logger) error {
 		return err
 	}
 
-	// Create health handler
-	mux := http.NewServeMux()
-	ms := http.Server{
-		Addr:    *healthAddr,
-		Handler: mux,
-	}
-	defer ms.Shutdown(context.Background())
-
-	mux.HandleFunc("/health/ready", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
-
 	logger.Info("Creating new gRPC server")
 	serverLogger := logger.Named("server")
 	server := grpc.NewServer(
@@ -99,6 +87,18 @@ func realMain(logger hclog.Logger) error {
 		Logger: serverLogger,
 	}
 	pb.RegisterCSIDriverProviderServer(server, s)
+
+	// Create health handler
+	mux := http.NewServeMux()
+	ms := http.Server{
+		Addr:    *healthAddr,
+		Handler: mux,
+	}
+	defer ms.Shutdown(context.Background())
+
+	mux.HandleFunc("/health/ready", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
 
 	// Start health handler
 	go func() {


### PR DESCRIPTION
In order to support readiness and liveness probes, we need a health handler. This creates a simple HTTP handler that return a 204 if it's receiving traffic.

The current e2e tests will automatically test this feature because I added the probes to the deployment and the setup code uses the `kubectl --wait` functionality. If the probes aren't working the pods will never go ready.