### PR TITLE
Add semver 2 versions to test charts

### DIFF
--- a/test/bats/configs/nginx/Chart.yaml
+++ b/test/bats/configs/nginx/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v3
 name: nginx-test
-version: test
+version: 0-test
 description: Testing chart to deploy pods which request secrets with configurable service accounts.

--- a/test/bats/configs/vault/Chart.yaml
+++ b/test/bats/configs/vault/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v3
 name: vault-test
-version: test
+version: 0-test
 description: Testing chart to deploy self-signed TLS certificates and a bootstrap script for Vault.


### PR DESCRIPTION
It looks like helm 3.5.3 is more strict about [chart versions and semver](https://helm.sh/docs/topics/charts/#charts-and-versioning). I was getting this error when setting up e2e tests locally:

```
helm install vault-bootstrap test/bats/configs/vault \
		--namespace=csi
Error: validation: chart.metadata.version "test" is invalid
make: *** [e2e-setup] Error 1
```

This PR just adds a 0 to satisfy semver 2.